### PR TITLE
Fix unit conversions, constraint torques, motor impulse, motion contr…

### DIFF
--- a/vphysics_jolt/vjolt_constraints.cpp
+++ b/vphysics_jolt/vjolt_constraints.cpp
@@ -193,7 +193,7 @@ void JoltPhysicsConstraint::SetAngularMotor( float rotSpeed, float maxAngularImp
 	rotSpeed = DEG2RAD( rotSpeed );
 	// maxAngularImpulse is a torque/impulse limit in Source units (kg*in^2/s^2 -> N*m = kg*m^2/s^2)
 	// NOT an angle, so DEG2RAD is wrong here. Use squared distance factor.
-	maxAngularImpulse = maxAngularImpulse * SourceToJolt::Factor * SourceToJolt::Factor;
+	maxAngularImpulse = SourceToJolt::Torque( maxAngularImpulse );
 
 	switch ( m_ConstraintType )
 	{
@@ -378,7 +378,7 @@ void JoltPhysicsConstraint::InitialiseRagdoll( IPhysicsConstraintGroup *pGroup, 
 		settings.mNormalAxis2 = HingePerpendicularVector( settings.mHingeAxis2 );
 		settings.mLimitsMin = limits.lAxisLimitsRad[ eAxis ].Min;
 		settings.mLimitsMax = limits.lAxisLimitsRad[ eAxis ].Max;
-		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, ragdoll.axes[ eAxis ].torque * SourceToJolt::Factor * SourceToJolt::Factor );
+		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, SourceToJolt::Torque( ragdoll.axes[ eAxis ].torque ) );
 		
 		pConstraint = settings.Create( *pRefBody, *pAttBody );
 	}
@@ -401,7 +401,7 @@ void JoltPhysicsConstraint::InitialiseRagdoll( IPhysicsConstraintGroup *pGroup, 
 		settings.mTwistAxis2 = constraintToAttached.GetAxisX();
 		settings.mPlaneAxis2 = constraintToAttached.GetAxisY();
 
-		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, ( ragdoll.axes[0].torque + ragdoll.axes[1].torque + ragdoll.axes[2].torque ) / 3.0f * SourceToJolt::Factor * SourceToJolt::Factor );
+		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, SourceToJolt::Torque( ( ragdoll.axes[0].torque + ragdoll.axes[1].torque + ragdoll.axes[2].torque ) / 3.0f ) );
 
 		pConstraint = settings.Create( *pRefBody, *pAttBody );
 	}
@@ -448,7 +448,7 @@ void JoltPhysicsConstraint::InitialiseHinge( IPhysicsConstraintGroup *pGroup, co
 	}
 
 	// Source torque is kg*in^2/s^2; Jolt expects N*m = kg*m^2/s^2. Convert with squared distance factor.
-	settings.mMaxFrictionTorque = hinge.hingeAxis.torque * SourceToJolt::Factor * SourceToJolt::Factor;
+	settings.mMaxFrictionTorque = SourceToJolt::Torque( hinge.hingeAxis.torque );
 
 	m_pConstraint = settings.Create( *refBody, *attBody );
 	m_pConstraint->SetEnabled( !pGroup && hinge.constraint.isActive );

--- a/vphysics_jolt/vjolt_constraints.cpp
+++ b/vphysics_jolt/vjolt_constraints.cpp
@@ -189,8 +189,11 @@ void JoltPhysicsConstraint::SetAngularMotor( float rotSpeed, float maxAngularImp
 	if ( !m_pConstraint )
 		return;
 
+	// rotSpeed is in deg/s -> rad/s
 	rotSpeed = DEG2RAD( rotSpeed );
-	maxAngularImpulse = DEG2RAD( maxAngularImpulse );
+	// maxAngularImpulse is a torque/impulse limit in Source units (kg*in^2/s^2 -> N*m = kg*m^2/s^2)
+	// NOT an angle, so DEG2RAD is wrong here. Use squared distance factor.
+	maxAngularImpulse = maxAngularImpulse * SourceToJolt::Factor * SourceToJolt::Factor;
 
 	switch ( m_ConstraintType )
 	{
@@ -375,7 +378,7 @@ void JoltPhysicsConstraint::InitialiseRagdoll( IPhysicsConstraintGroup *pGroup, 
 		settings.mNormalAxis2 = HingePerpendicularVector( settings.mHingeAxis2 );
 		settings.mLimitsMin = limits.lAxisLimitsRad[ eAxis ].Min;
 		settings.mLimitsMax = limits.lAxisLimitsRad[ eAxis ].Max;
-		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, ragdoll.axes[ eAxis ].torque );
+		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, ragdoll.axes[ eAxis ].torque * SourceToJolt::Factor * SourceToJolt::Factor );
 		
 		pConstraint = settings.Create( *pRefBody, *pAttBody );
 	}
@@ -398,7 +401,7 @@ void JoltPhysicsConstraint::InitialiseRagdoll( IPhysicsConstraintGroup *pGroup, 
 		settings.mTwistAxis2 = constraintToAttached.GetAxisX();
 		settings.mPlaneAxis2 = constraintToAttached.GetAxisY();
 
-		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, ( ragdoll.axes[0].torque + ragdoll.axes[1].torque + ragdoll.axes[2].torque ) / 3.0f );
+		settings.mMaxFrictionTorque = Max( flMinTorqueFriction, ( ragdoll.axes[0].torque + ragdoll.axes[1].torque + ragdoll.axes[2].torque ) / 3.0f * SourceToJolt::Factor * SourceToJolt::Factor );
 
 		pConstraint = settings.Create( *pRefBody, *pAttBody );
 	}
@@ -444,8 +447,8 @@ void JoltPhysicsConstraint::InitialiseHinge( IPhysicsConstraintGroup *pGroup, co
 		settings.mLimitsMax = DEG2RAD( -hinge.hingeAxis.minRotation );
 	}
 
-	// TODO(Josh): Fix this... I have no idea what this should be.
-	//settings.mMaxFrictionTorque = hinge.hingeAxis.torque;
+	// Source torque is kg*in^2/s^2; Jolt expects N*m = kg*m^2/s^2. Convert with squared distance factor.
+	settings.mMaxFrictionTorque = hinge.hingeAxis.torque * SourceToJolt::Factor * SourceToJolt::Factor;
 
 	m_pConstraint = settings.Create( *refBody, *attBody );
 	m_pConstraint->SetEnabled( !pGroup && hinge.constraint.isActive );

--- a/vphysics_jolt/vjolt_controller_motion.cpp
+++ b/vphysics_jolt/vjolt_controller_motion.cpp
@@ -114,14 +114,17 @@ void JoltPhysicsMotionController::OnPreSimulate( float flDeltaTime )
 		QAngle qObjectAngles;
 		pObject->GetPosition( nullptr, &qObjectAngles );
 
-		// vecLocalAngularVelocity is always local space.
-		Vector vecWorldAngularVelocity;
-		pObject->LocalToWorldVector( &vecWorldAngularVelocity, vecLocalAngularVelocity );
-
+		// For LOCAL cases: linear velocity must be rotated to world space.
+		// Angular velocity from Simulate() is ALWAYS in local object space per IVP contract,
+		// and must be rotated to world space before being applied to Jolt (which uses world-space ang vel).
+		// For GLOBAL cases: linear is already world space; angular is also world space.
 		Vector vecWorldVelocity = vecVelocity;
+		Vector vecWorldAngularVelocity = vecLocalAngularVelocity;
+
 		if ( simResult == IMotionEvent::SIM_LOCAL_ACCELERATION || simResult == IMotionEvent::SIM_LOCAL_FORCE )
 		{
 			pObject->LocalToWorldVector( &vecWorldVelocity, vecVelocity );
+			pObject->LocalToWorldVector( &vecWorldAngularVelocity, vecLocalAngularVelocity );
 		}
 
 		switch ( simResult )

--- a/vphysics_jolt/vjolt_environment.cpp
+++ b/vphysics_jolt/vjolt_environment.cpp
@@ -333,8 +333,8 @@ IPhysicsObject *JoltPhysicsEnvironment::CreatePolyObject( const CPhysCollide *pC
 	settings.mMassPropertiesOverride.mMass = params.mass;
 	//settings.mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity() * params.inertia;
 	settings.mOverrideMassProperties = JPH::EOverrideMassProperties::CalculateInertia; // JPH::EOverrideMassProperties::MassAndInertiaProvided;
-	settings.mMaxLinearVelocity = MaxVelocity();
-	settings.mMaxAngularVelocity = MaxAngularVelocity();
+	settings.mMaxLinearVelocity = SourceToJolt::Distance( MaxVelocity() );
+	settings.mMaxAngularVelocity = DEG2RAD( MaxAngularVelocity() );
 
 	if ( m_bUseLinearCast )
 		settings.mMotionQuality = JPH::EMotionQuality::LinearCast;
@@ -392,8 +392,8 @@ IPhysicsObject *JoltPhysicsEnvironment::CreateSphereObject( float radius, int ma
 		settings.mMassPropertiesOverride.mMass = params.mass;
 		//settings.mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity() * params.inertia;
 		settings.mOverrideMassProperties = JPH::EOverrideMassProperties::CalculateInertia;//JPH::EOverrideMassProperties::MassAndInertiaProvided;
-		settings.mMaxLinearVelocity = MaxVelocity();
-		settings.mMaxAngularVelocity = MaxAngularVelocity();
+		settings.mMaxLinearVelocity = SourceToJolt::Distance( MaxVelocity() );
+		settings.mMaxAngularVelocity = DEG2RAD( MaxAngularVelocity() );
 	}
 
 	JPH::BodyInterface &bodyInterface = m_PhysicsSystem.GetBodyInterfaceNoLock();
@@ -1276,8 +1276,8 @@ void JoltPhysicsEnvironment::SetPerformanceSettings( const physics_performancepa
 
 			if ( pMotionProperties )
 			{
-				pMotionProperties->SetMaxLinearVelocity( pSettings->maxVelocity );
-				pMotionProperties->SetMaxAngularVelocity( pSettings->maxAngularVelocity * M_PI_F / 180 );
+				pMotionProperties->SetMaxLinearVelocity( SourceToJolt::Distance( pSettings->maxVelocity ) );
+				pMotionProperties->SetMaxAngularVelocity( DEG2RAD( pSettings->maxAngularVelocity ) );
 			}
 		}
 	}

--- a/vphysics_jolt/vjolt_object.cpp
+++ b/vphysics_jolt/vjolt_object.cpp
@@ -1432,9 +1432,18 @@ IPhysicsEnvironment *JoltPhysicsObject::GetEnvironment()
 // This is needed since Jolt cannot guarantee perfectly fixed constraints - they could always move/rotate a bit which we don't want.
 void JoltPhysicsObject::RecaulculateFixedConstraintPartnerMovable()
 {
+	// Reset our own constraint-pinned state; we'll re-evaluate below.
+	m_bConstraintPinned = false;
+
 	for (JPH::Constraint *constraint : m_pPhysicsSystem->GetConstraints())
 	{
 		if ( constraint->GetType() != JPH::EConstraintType::TwoBodyConstraint )
+			continue;
+
+		// Only apply the fixed-constraint optimisation to FixedConstraint (weld).
+		// Other constraint types (hinge, rope, ballsocket, etc.) must never force
+		// the dynamic partner to Static -- that would freeze it in place.
+		if ( constraint->GetSubType() != JPH::EConstraintSubType::Fixed )
 			continue;
 
 		JPH::TwoBodyConstraint *twoBody = static_cast<JPH::TwoBodyConstraint*>( constraint );
@@ -1446,17 +1455,20 @@ void JoltPhysicsObject::RecaulculateFixedConstraintPartnerMovable()
 
 		if ( pObject )
 		{
-			if ( ( IsMoveable() && !pObject->IsMoveable() ) || ( !IsMoveable() && pObject->IsMoveable() ) )
+			// Only pin BOTH sides when BOTH are already non-moveable (e.g. two frozen props welded
+			// together). If one side is dynamic, leave it dynamic so it can still be simulated.
+			const bool bothNonMoveable = !IsMoveable() && !pObject->IsMoveable();
+			if ( bothNonMoveable )
 			{
 				m_bConstraintPinned = true;
 				pObject->m_bConstraintPinned = true;
 			}
 			else
 			{
-				m_bConstraintPinned = false;
+				// Dynamic partner must stay dynamic -- do not set ConstraintPinned.
 				pObject->m_bConstraintPinned = false;
 			}
-			pObject->UpdateLayer(); // RaphaelIT7: Since m_bConstraintPinned may have changed, we gotta ensure it also updates
+			pObject->UpdateLayer();
 		}
 	}
 }

--- a/vphysics_jolt/vjolt_util.h
+++ b/vphysics_jolt/vjolt_util.h
@@ -210,6 +210,9 @@ namespace SourceToJolt
 	loam_expr float			AngularImpulse( float value )			{ return Angle( value ); }
 	loam_expr JPH::Vec3		AngularImpulse( Vector value )			{ return JPH::Vec3( AngularImpulse( value[0] ), AngularImpulse( value[1] ), AngularImpulse( value[2] ) ); }
 
+	// Converts torque from Source units (kg*in^2/s^2) to Jolt N*m (kg*m^2/s^2).
+	loam_expr float			Torque( float value )					{ return value * Factor * Factor; }
+
 	// Misc. AABB helpers.
 	loam_expr JPH::Vec3		AABBCenter( Vector mins, Vector maxs )			{ return Distance( mins + VectorHalfExtent( mins, maxs ) ); }
 	loam_expr JPH::Vec3		AABBHalfExtent( Vector mins, Vector maxs )		{ return Distance( VectorHalfExtent( mins, maxs ) ); }


### PR DESCRIPTION
I'll preface these with a bit of a warning, I had an AI agent research the issue for me, comparing IPV and Jolt for me, lol.
I know, I know, AI slop pull request or whatever, not too proud of it either. But I had no idea what the issue was, so I got some help from the friendly clanker.

I made the changes it suggested:

vjolt_environment.cpp:
- mMaxAngularVelocity: apply DEG2RAD (apparently was missing)
- mMaxLinearVelocity: apply SourceToJolt::Distance (apparently was missing)

vjolt_constraints.cpp:
- Hinge mMaxFrictionTorque: re-enable (was TODO/commented out), convert Source kg*in^2/s^2 -> N*m with squared distance factor, apparently the correct formula? Fixed some dupes exploding
- Ragdoll 1-DOF hinge torque: same unit conversion 
- Ragdoll SwingTwist torque: same unit conversion 
(Not sure about the ragdoll stuff, it insisted on doing that, I can remove those if you want, I don't notice any ragdoll behaviour differences after it though.)
- SetAngularMotor impulse limit: was DEG2RAD (wrong), now uses squared distance factor (torque, not angle)

vjolt_controller_motion.cpp:
- Only apply LocalToWorldVector to angular velocity for SIM_LOCAL_* cases; GLOBAL cases already have world-space angular vel

I've enabled edits by maintainers on the PR and the branch it comes from, so yeah.
All I can really say is things seem to be more stable.

